### PR TITLE
Create .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source =
+    .
+omit =
+    tests/*
+
+[report]
+show_missing = True
+fail_under = 95
+exclude_lines =
+    pragma: no cover
+    ^\s*if __name__ == ['"]__main__['"]:


### PR DESCRIPTION
exclui bloco __main__ do relatório para refletir apenas código testável